### PR TITLE
delete relative path when running command from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node_modules/.bin/webpack-dev-server",
+    "start": "webpack-dev-server",
     "test": "npm run lint ; mocha --compilers js:babel-core/register --require ./test/react/test_helper.js 'test/testSeq.js'",
     "test:watch": "npm run test -- --watch",
-    "lint": "./node_modules/.bin/eslint --ext=jsx --ext=js src/ test/",
-    "dist": "rm -rf dist/bundle.js dist/*.svg && ./node_modules/.bin/webpack --config webpack.production.config.js",
-    "deploy": "npm run dist -- && node_modules/.bin/firebase login && node_modules/.bin/firebase deploy && node_modules/.bin/firebase open"
+    "lint": "eslint --ext=jsx --ext=js src/ test/",
+    "dist": "rm -rf dist/bundle.js dist/*.svg && webpack --config webpack.production.config.js",
+    "deploy": "npm run dist -- && firebase login && firebase deploy && firebase open"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm recognises already the packages that has installed so there is no need to reference them explicitelly using the path to test this you can try the following:
in the `package.json` you can add the following **script** 

`"testing_where_is_eslint_package": "which eslint"`

that will show you the path to your actual eslint package (inside node_modules) so `eslint` can be reffered without using the full path (same for the rest)
